### PR TITLE
set actions to use deploy_keys, !github_token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_branch: gh-pages
           publish_dir: ./public
           cname: blog.obimadu.pro

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Deploy (Staging)
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.STAGING_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: obiMadu/blog-staging
           publish_dir: ./public
           publish_branch: gh-pages


### PR DESCRIPTION
So github_token for the actions workflow has some limitations. When it's in use, one still has to manually go and setup pages deployment from the repo settings. The manual setup creates a new 'github-pages' deployment environment, which is not what I need (want). Prod and stage deployments are all I want!